### PR TITLE
Add a .desktop file to make DEs autostart redshift-scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Copy the ``redshift-scheduler`` executable file anywhere you'd like.
 
 Copy the default rules file (``resources/rules.conf.dist``) to ``~/.config/redshift-scheduler/rules.conf``.
 
+Copy the desktop file (``resources/redshift-scheduler.desktop``) to ``~/.local/share/applications/``.
+This will allow to add the tool as a startup item using e.g. the [GNOME Tweak Tool](https://wiki.gnome.org/Apps/GnomeTweakTool)
+
 Make sure you have [redshift](http://jonls.dk/redshift/) installed, as **redshift-scheduler** depends on it.
 
 
@@ -90,6 +93,7 @@ A package would:
 
  - build the executable and stage it for copying to ``/usr/bin/`` or some other such location
  - stage ``resources/rules.conf.dist`` (the default config) for copying to ``/usr/share/redshift-scheduler/rules.conf.dist``
+ - stage ``resources/redshift-scheduler.desktop`` (the desktop file) for copying to ``/usr/share/applications/``
 
 Dependencies:
 

--- a/redshift-scheduler.desktop
+++ b/redshift-scheduler.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Icon=redshift
+Name=Redshift Scheduler
+Comment=Adjusts screen color temperature according to time of the day and location
+Exec=redshift-scheduler
+Terminal=false
+Type=Application
+X-GNOME-Autostart-Enabled=true

--- a/resources/redshift-scheduler.desktop
+++ b/resources/redshift-scheduler.desktop
@@ -5,4 +5,4 @@ Comment=Adjusts screen color temperature according to time of the day and locati
 Exec=redshift-scheduler
 Terminal=false
 Type=Application
-X-GNOME-Autostart-Enabled=true
+Category=Utility;

--- a/resources/redshift-scheduler.desktop
+++ b/resources/redshift-scheduler.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Icon=redshift
 Name=Redshift Scheduler
-Comment=Adjusts screen color temperature according to time of the day and location
+Comment=Adjusts screen color temperature according to your own rules controlling redshift
 Exec=redshift-scheduler
 Terminal=false
 Type=Application


### PR DESCRIPTION
This allows to make desktop environments compliant with the XDG autostart
specification to run redshift-scheduler when the user logs in. It has been
tested to work under GNOME, but it should work with other DEs that follow
the specification.